### PR TITLE
Setting value for Toggle Switch in Customer Status column

### DIFF
--- a/client/src/components/BtnCellRenderer.jsx
+++ b/client/src/components/BtnCellRenderer.jsx
@@ -10,7 +10,7 @@ export default class BtnCellRenderer extends Component {
     render() {
       return (
         <label className="switch">
-        <input type="checkbox"/>
+        <input type="checkbox" checked={this.props.data.customerStatus}/>
           <span className="slider round"></span>
       </label>
       )


### PR DESCRIPTION
Previously the toggle switch was set to "OFF" irrespective of true customer status.
Now, the value is set based on what is returned by the API